### PR TITLE
Allow pre-specified hub_id in turtles

### DIFF
--- a/turtle.lua
+++ b/turtle.lua
@@ -8,6 +8,16 @@ for _, filename in pairs(fs.list('/disk/turtle_files')) do
     fs.copy('/disk/turtle_files/' .. filename, '/' .. filename)
 end
 
+if fs.exists('/hub_id') then
+    file = fs.open('/hub_id', 'r')
+    hub_id = tonumber(file.readAll())
+    file.close()
+    if hub_id then
+        sleep(1)
+        os.reboot()
+    end
+end
+
 print("Enter ID of Hub computer to link to: ")
 hub_id = tonumber(read())
 if hub_id == nil then


### PR DESCRIPTION
Allows the turtle script to use a pre-existing `hub_id` if one is already present, to enable zero-touch provisioning of new turtles